### PR TITLE
De-Linting and Small Format Revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.log
 *.py[cod]
 *.yml
+build/*

--- a/eapeak
+++ b/eapeak
@@ -1,42 +1,71 @@
 #!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  eapeak
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-"""
-	-*- coding: utf-8 -*-
-	eapeak
-	
-	Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-	
-	Shout outs to the SecureState Profiling Team (Thanks Guys!)
-	agent0x0
-	f8lerror
-	jagar
-	WhIPsmACK0
-	Zamboni
-	
-	Additional Thanks To:
-	Joshua Wright
-	
-	Zero_Chaos
-	Steve Ocepek
-		
-"""
+# native imports
+import argparse
+try:
+	import curses # pylint: disable=unused-import
+	curses_enabled = True
+except ImportError:
+	curses_enabled = False
+import logging
+import os
+from select import error as select_error
+from socket import error as socketError	# needed for the error
+import sys
+import thread
+
+# project imports
+from eapeak.parse import CursesEapeakParsingEngine # pylint: disable=no-name-in-module
+try:																	# default to the systems libraries
+	from eapeak.parse import EapeakParsingEngine						# revert to ./lib on fail for development
+except ImportError:
+	sys.path.append(os.path,join(os.path.dirname(__file__), 'lib'))
+	from eapeak.parse import EapeakParsingEngine # pylint: disable=no-name-in-module
+
+# external imports
+try:
+	from M2Crypto import X509
+except ImportError:
+	print('Error: Missing M2Crypto, Please Install The M2Crypto Libraries')
+	print('Error: Now Exiting...')
+	sys.exit(1)
+from scapy.config import conf
+from scapy.sendrecv import sniff
 
 __version_major__ = '0'
 __version_minor__ = '1'
@@ -44,75 +73,66 @@ __version_build__ = '5'
 __version__ = "{0}.{1}.{2}".format(__version_major__, __version_minor__, __version_build__)
 del __version_major__, __version_minor__, __version_build__
 
-__authors__ = [ 'Spencer McIntyre', 'SecureState R&D Team' ]
-
-import sys
-try:
-	from scapy.layers.l2 import eap_types as EAP_TYPES
-	from scapy.layers.l2 import WPS
-except ImportError:
-	print 'Error: Missing Scapy Libraries, Please Install Scapy From The Community Repository'
-	print 'Error: Version Must Be >= 1538:d80170e42ced'
-	# http://hg.secdev.org/scapy-com # needs community repository because of the extra EAP layers I added.
-	print 'Error: Now Exiting...'
-	sys.exit(1)
+__authors__ = ['Spencer McIntyre', 'SecureState R&D Team']
 
 def main():
-	import os
-	from socket import error as socketError	# needed for the error
-	import thread
-	import logging
-	import argparse
-	from select import error as select_error
-	try:
-		import curses
-		curses_enabled = True
-	except ImportError:
-		curses_enabled = False
-	
-	from scapy.config import conf
-	try:
-		from M2Crypto import X509
-	except ImportError:
-		print 'Error: Missing M2Crypto, Please Install The M2Crypto Libraries'
-		print 'Error: Now Exiting...'
-		return 1
-		
 	# these edit the load_layers configuration to keep layers we don't need out and consume less memory
-	not_needed_layers = [	'bluetooth', 'cdp', 'dhcp', 'dhcp6', 'dns', 'eigrp', 'hsrp', 'inet6', 'ir',
-							'isakmp', 'l2tp', 'llmnr', 'mgcp', 'mobileip', 'netbios', 'netflow', 'ntp',
-							'ospf', 'ppi_cace', 'ppi_geotag', 'ppi', 'ppp', 'rip', 'rtp', 'sctp', 'sebek',
-							'skinny', 'smb', 'snmp', 'tftp', 'vrrp', 'x509'
-						]
+	not_needed_layers = [
+		'bluetooth',
+		'cdp',
+		'dhcp',
+		'dhcp6',
+		'dns',
+		'eigrp',
+		'hsrp',
+		'inet6',
+		'ir',
+		'isakmp',
+		'l2tp',
+		'llmnr',
+		'mgcp',
+		'mobileip',
+		'netbios',
+		'netflow',
+		'ntp',
+		'ospf',
+		'ppi_cace',
+		'ppi_geotag',
+		'ppi',
+		'ppp',
+		'rip',
+		'rtp',
+		'sctp',
+		'sebek',
+		'skinny',
+		'smb',
+		'snmp',
+		'tftp',
+		'vrrp',
+		'x509'
+	]
 
 	for layer in not_needed_layers:
 		if layer in conf.load_layers:
 			conf.load_layers.remove(layer)
 	del layer, not_needed_layers
 	conf.ipv6_enabled = False
-	from scapy.sendrecv import sniff
-	try:																	# default to the systems libraries
-		from eapeak.parse import EapeakParsingEngine						# revert to ./lib on fail for development
-	except ImportError:
-		sys.path.append(os.getcwd() + os.sep + 'lib')
-		from eapeak.parse import EapeakParsingEngine
-	from eapeak.parse import CursesEapeakParsingEngine
 	
-	parser = argparse.ArgumentParser(description = 'EAPeak: Analysis tool for EAP enabled wireless networks', conflict_handler='resolve')
-	parser.add_argument('-f', '--file', dest = 'pcaps', nargs = '+', action = 'store', default = [], help = 'the path to the PCap file(s)')
-	parser.add_argument('-s', '--ssid', dest = 'target_ssids', nargs = '+', action = 'store', help = 'specific SSID(s) to analyze')
-	parser.add_argument('-l', '--live', dest = 'capture_live', action = 'store_true', default = False, help = 'analyze packets live')
+	parser = argparse.ArgumentParser(description='EAPeak: Analysis tool for EAP enabled wireless networks', conflict_handler='resolve')
+	parser.add_argument('-f', '--file', dest='pcaps', nargs='+', action='store', default=[], help='the path to the PCap file(s)')
+	parser.add_argument('-s', '--ssid', dest='target_ssids', nargs='+', action='store', help='specific SSID(s) to analyze')
+	parser.add_argument('-l', '--live', dest='capture_live', action='store_true', default=False, help='analyze packets live')
 	if curses_enabled:
-		parser.add_argument('-c', '--curses', dest = 'use_curses', action = 'store_true', default = False, help = 'use the BETA curses interface when capturing live')
-	parser.add_argument('-i', '--iface', dest = 'interface', action = 'store', help = 'interface to use when capturing live')
-	parser.add_argument('-v', '--version', action = 'version', version = parser.prog + ' Version: ' + __version__)
+		parser.add_argument('-c', '--curses', dest='use_curses', action='store_true', default=False, help='use the BETA curses interface when capturing live')
+	parser.add_argument('-i', '--iface', dest='interface', action='store', help='interface to use when capturing live')
+	parser.add_argument('-v', '--version', action='version', version=parser.prog + ' Version: ' + __version__)
 	save_xml_parser = parser.add_mutually_exclusive_group()
-	save_xml_parser.add_argument('--no-xml', dest = 'dont_save_xml', action = 'store_true', default = False, help = 'don\'t export data to xml (default: save when capturing)')
-	save_xml_parser.add_argument('--xml', dest = 'save_xml', action = 'store_true', default = False, help = 'export data to xml (default: save when capturing)')
+	save_xml_parser.add_argument('--no-xml', dest='dont_save_xml', action='store_true', default=False, help='don\'t export data to xml (default: save when capturing)')
+	save_xml_parser.add_argument('--xml', dest='save_xml', action='store_true', default=False, help='export data to xml (default: save when capturing)')
 
 	cert_opts = parser.add_argument_group('access-point certificate export options')
-	cert_opts.add_argument('--export-x509', dest = 'export_x509', action = 'store_true', default = False, help = 'start EAPeak certificate export wizard')
-	cert_opts.add_argument('--x509-format', dest = 'export_x509_format', action = 'store', choices = ['der', 'pem'], default = 'pem', help = 'format to save certificates as, default: pem')
+	cert_opts.add_argument('--export-x509', dest='export_x509', action='store_true', default=False, help='start EAPeak certificate export wizard')
+	cert_opts.add_argument('--x509-format', dest='export_x509_format', action='store', choices=['der', 'pem'], default='pem', help='format to save certificates as, default: pem')
 
 	results = parser.parse_args()
 	storedFiles = results.pcaps
@@ -133,12 +153,12 @@ def main():
 	del results, parser, cert_opts
 	
 	if capture_live and not interface:
-		print 'Error: You must specify an interface when using live mode.'
+		print('Error: You must specify an interface when using live mode.')
 		return 1
 	if capture_live and os.getuid():
-		print 'Error: You must be root when using live mode.'
+		print('Error: You must be root when using live mode.')
 		return 1
-	print """
+	print("""
  ________ 
 < eapeak >
  -------- 
@@ -147,8 +167,8 @@ def main():
             (__)\       )\\/\\
                 ||----w |
                 ||     ||
-"""
-	print 'Welcome To EAPeak\nVersion: ' + __version__ + '\n'
+""")
+	print('Welcome To EAPeak\nVersion: ' + __version__ + '\n')
 	
 	# adjust the scapy logs to make them quiet, a hat tip to Philippe Biondi for setting it up so nicely
 	scapy_runtime_log = logging.getLogger("scapy.runtime")
@@ -167,14 +187,14 @@ def main():
 			if filename in xmlFiles:
 				continue
 			if not os.access(filename, os.R_OK):
-				print 'Error: Could not read file \'' + filename + '\' (invalid permissions)'
+				print('Error: Could not read file \'' + filename + '\' (invalid permissions)')
 				continue
 			xmlFiles.append(filename)
 		elif 'cap' in filename.split('.')[-1]:
 			if filename in pcapFiles:
 				continue
 			if not os.access(filename, os.R_OK):
-				print 'Error: Could not read file \'' + filename + '\' (invalid permissions)'
+				print('Error: Could not read file \'' + filename + '\' (invalid permissions)')
 				continue
 			pcapFiles.append(filename)
 				
@@ -182,25 +202,25 @@ def main():
 		eapeakParser.parseXMLFiles(xmlFiles, False)
 	if pcapFiles:
 		eapeakParser.parsePCapFiles(pcapFiles, False)
-	print ''
+	print('')
 	del pcapFiles, xmlFiles, storedFiles
 	
 	if capture_live:
-		print 'Begining Live Capture...'
+		print('Begining Live Capture...')
 		if use_curses:
 			errCode = eapeakParser.initCurses()
 			if errCode:
-				print {1:'Screen must be at least 99x25 for Curses'}[errCode]
+				print({1:'Screen must be at least 99x25 for Curses'}[errCode])
 				return 1
 			del errCode
 			timeout = 1.5
-			thread.start_new_thread(eapeakParser.cursesInteractionHandler, () )
-			thread.start_new_thread(eapeakParser.cursesScreenDrawHandler, (save_to_xml, ) )	# tuples are stupid
+			thread.start_new_thread(eapeakParser.cursesInteractionHandler, ())
+			thread.start_new_thread(eapeakParser.cursesScreenDrawHandler, (save_to_xml, ))	# tuples are stupid
 		else:
 			timeout = None
 		while True:
 			try:
-				sniff(iface = interface, store = 0, prn = lambda packet: eapeakParser.parseLiveCapture(packet, use_curses), timeout = timeout )
+				sniff(iface=interface, store=0, prn=lambda packet: eapeakParser.parseLiveCapture(packet, use_curses), timeout=timeout)
 				if (use_curses and not eapeakParser.curses_enabled) or not use_curses:
 					break
 			except KeyboardInterrupt:
@@ -208,7 +228,7 @@ def main():
 			except socketError:
 				if use_curses:
 					eapeakParser.cleanupCurses()
-				print 'Error: Invalid Interface'
+				print('Error: Invalid Interface')
 				return 0
 			except select_error:
 				if use_curses and not eapeakParser.curses_enabled:
@@ -216,11 +236,11 @@ def main():
 		del timeout
 		if use_curses:
 			eapeakParser.cleanupCurses()
-		print '\nStopping Live Capture...'
-		print ''
+		print('\nStopping Live Capture...')
+		print('')
 	
 	if not len(eapeakParser.KnownNetworks):
-		print 'Found No Usable Information\nTry Again With A Larger Capture'
+		print('Found No Usable Information\nTry Again With A Larger Capture')
 		return 0		# we didn't find anything don't continue
 	elif export_x509:	# I HATE menu driven programs with a passion
 		networks = eapeakParser.KnownNetworks.keys()
@@ -231,7 +251,7 @@ def main():
 			for cert in network.x509certs:
 				certs[cert] = network.ssid
 		if len(certs) == 0:
-			print 'No Certificates Are Available For Exporting'
+			print('No Certificates Are Available For Exporting')
 			return 0
 		output = '\nAvailable Certificates:\n'
 		i = 1
@@ -253,25 +273,25 @@ def main():
 			del data
 			output += '\n\n'
 			i += 1
-		print output[:-1]
+		print(output[:-1])
 		del output
 		tries = 3
 		while tries:
 			try:
 				target = raw_input('Certificate To Export (1 - ' + str(i - 1) + '): ')
 			except KeyboardInterrupt:
-				print ''
+				print('')
 				return 0
 			if target.isdigit() and 0 < int(target) < i:
 				target = int(target)
 				break
 			else:
-				print 'Invalid Certificate.'
+				print('Invalid Certificate.')
 				target = None
 			tries -= 1
 		del i, tries
-		if target == None:
-			print 'Now Exiting...'
+		if target is None:
+			print('Now Exiting...')
 			return 0
 		cert = certs.keys()[target - 1]
 		
@@ -279,17 +299,17 @@ def main():
 			filename = certs.values()[target - 1] + '_cert.crt'
 			try:
 				cert.save(filename, X509.FORMAT_DER)
-				print 'Certificate Successfully Saved To: ' + filename
-			except:
-				print 'There Was An Error Saving The Certificate...'
+				print('Certificate Successfully Saved To: ' + filename)
+			except: # pylint: disable=bare-except
+				print('There Was An Error Saving The Certificate...')
 		elif export_x509_format in ['pem', 'PEM']:
 			filename = certs.values()[target - 1] + '_cert.pem'
 			try:
 				cert.save(filename, X509.FORMAT_PEM)
-				print 'Certificate Successfully Saved To: ' + filename 
-			except:
-				print 'There Was An Error Saving The Certificate...'
-		print 'Now Exiting...'
+				print('Certificate Successfully Saved To: ' + filename)
+			except: # pylint: disable=bare-except
+				print('There Was An Error Saving The Certificate...')
+		print('Now Exiting...')
 		return 0
 
 	if save_to_xml:
@@ -300,13 +320,13 @@ def main():
 	intro += '* ' + intro0 + ' *\n'
 	intro += '* ' + intro1 + ' ' * (len(intro0) - len(intro1)) + ' *\n'
 	intro += '*' * len(intro0) + '****\n'
-	print intro
+	print(intro)
 	del intro, intro0, intro1
 	networks = eapeakParser.KnownNetworks.keys()
 	networks.sort()
 	for network in networks:
-		print eapeakParser.KnownNetworks[network].show()
-		print ''
+		print(eapeakParser.KnownNetworks[network].show())
+		print('')
 
 	return 0
 

--- a/eapscan
+++ b/eapscan
@@ -1,62 +1,105 @@
 #!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  eapscan
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-"""
-	-*- coding: utf-8 -*-
-	eapscan
-	
-	Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-		
-"""
+# native imports
+import argparse
+import logging
+from os import getuid
+import sys
+from time import sleep
+
+# project imports
+from eapeak.common import checkInterface, setInterfaceChannel
+from eapeak.inject import WirelessStateMachine, WirelessStateMachineEAP
+from eapeak.networks import WirelessNetwork
+from eapeak.parse import EapeakParsingEngine
+from ipfunc import sanitizeMAC
+
+# external imports
+from scapy.config import conf
+try:
+	from scapy.layers.l2 import eap_types as EAP_TYPES
+except ImportError:
+	print('Error: Missing Scapy Libraries, Please Install Scapy From The Community Repository')
+	# http://hg.secdev.org/scapy-com # needs community repository because of the extra EAP layers I added.
+	print('Error: Now Exiting...')
+	sys.exit(1)
+from scapy.volatile import RandMAC
 
 # TODO: Add verbosity options to display BSSID and Client MAC addresses
 
 __version__ = '0.0.7'
-__authors__ = [ 'Spencer McIntyre', 'SecureState R&D Team' ]
+__authors__ = ['Spencer McIntyre', 'SecureState R&D Team']
 
-import sys
-try:
-	from scapy.layers.l2 import eap_types as EAP_TYPES
-except ImportError:
-	print 'Error: Missing Scapy Libraries, Please Install Scapy From The Community Repository'
-	# http://hg.secdev.org/scapy-com # needs community repository because of the extra EAP layers I added.
-	print 'Error: Now Exiting...'
-	sys.exit(1)
-
-import argparse
-import logging
-from time import sleep
-from os import getuid
-
-from eapeak.common import checkInterface, setInterfaceChannel
-from eapeak.parse import EapeakParsingEngine
-from eapeak.networks import WirelessNetwork
-from eapeak.inject import WirelessStateMachine, WirelessStateMachineEAP
-from ipfunc import sanitizeMAC, getHwAddr
-
-from scapy.config import conf
 # these edit the load_layers configuration to keep layers we don't need out and consume less memory
-not_needed_layers = [	'bluetooth', 'cdp', 'dhcp', 'dhcp6', 'dns', 'eigrp', 'hsrp', 'inet6', 'ir',
-						'isakmp', 'l2tp', 'llmnr', 'mgcp', 'mobileip', 'netbios', 'netflow', 'ntp',
-						'ospf', 'ppi_cace', 'ppi_geotag', 'ppi', 'ppp', 'rip', 'rtp', 'sctp', 'sebek',
-						'skinny', 'smb', 'snmp', 'tftp', 'vrrp', 'x509'
-					]
+not_needed_layers = [
+	'bluetooth',
+	'cdp',
+	'dhcp',
+	'dhcp6',
+	'dns',
+	'eigrp',
+	'hsrp',
+	'inet6',
+	'ir',
+	'isakmp',
+	'l2tp',
+	'llmnr',
+	'mgcp',
+	'mobileip',
+	'netbios',
+	'netflow',
+	'ntp',
+	'ospf',
+	'ppi_cace',
+	'ppi_geotag',
+	'ppi',
+	'ppp',
+	'rip',
+	'rtp',
+	'sctp',
+	'sebek',
+	'skinny',
+	'smb',
+	'snmp',
+	'tftp',
+	'vrrp',
+	'x509'
+]
 
 for layer in not_needed_layers:
 	if layer in conf.load_layers:
@@ -64,7 +107,6 @@ for layer in not_needed_layers:
 del layer, not_needed_layers
 conf.ipv6_enabled = False
 
-from scapy.volatile import RandMAC
 EAP_TYPES[0] = 'NONE'
 scapy_runtime_log = logging.getLogger("scapy.runtime")
 scapy_runtime_log.setLevel(logging.CRITICAL)
@@ -74,7 +116,7 @@ STATUS = '\033[1;34m[*]\033[1;m '
 ERROR = '\033[1;31m[-]\033[1;m '
 ERROR_SLEEP_TIME = 1.5	# time to wait between error and retry
 
-def eap_scan(interface, bssid, essid, check_range, outer_identity, verbose = False):
+def eap_scan(interface, bssid, essid, check_range, outer_identity, verbose=False):
 	valid_eap_types = []
 	tries = 0
 	while tries < 5:
@@ -134,7 +176,7 @@ def eap_scan(interface, bssid, essid, check_range, outer_identity, verbose = Fal
 					statemachine.close()
 					sys.stdout.write((' ' * len(status_str)) + '\r')
 					sys.stdout.flush()
-					print ERROR + 'Identity String \'' + outer_identity + '\' Was Rejected'
+					print(ERROR + 'Identity String \'' + outer_identity + '\' Was Rejected')
 					return valid_eap_types	# should be empty but return it anyways
 			if tries == 0:
 				continue
@@ -144,7 +186,7 @@ def eap_scan(interface, bssid, essid, check_range, outer_identity, verbose = Fal
 			sys.stdout.write(status_str)	# haha STD
 			sys.stdout.flush()
 	except KeyboardInterrupt:
-		print '\n' + STATUS + 'Caught Ctrl+C'
+		print('\n' + STATUS + 'Caught Ctrl+C')
 		return valid_eap_types
 	sys.stdout.write(' ' * len(status_str) + '\n') # overwrite checking stuff
 	sys.stdout.flush()
@@ -155,7 +197,7 @@ def wps_scan(interface, bssid, essid):
 	This is very similar to running eapscan with the following options and is essentially a short cut
 	eapscan -c 11 -b 00:11:22:33:44:55 -e linksys -i mon0 --identity WFA-SimpleConfig-Registrar-1-0 --types 254
 	"""
-	print STATUS + 'Checking for WPS...'
+	print(STATUS + 'Checking for WPS...')
 	try:
 		tries = 0
 		while tries < 5:
@@ -168,10 +210,10 @@ def wps_scan(interface, bssid, essid):
 			errCode = statemachine.check_eap_type(254, 'WFA-SimpleConfig-Registrar-1-0', True)	# 254 is extended
 			if errCode == 0:	# supported
 				statemachine.close()
-				print GOOD + 'WPS Is Supported'
+				print(GOOD + 'WPS Is Supported')
 				return True
 			elif errCode == 1:	# not supported
-				print STATUS + 'WPS Is Not Supported'
+				print(STATUS + 'WPS Is Not Supported')
 				return False
 			elif errCode == 2:	# unknown error
 				sleep(ERROR_SLEEP_TIME)
@@ -179,14 +221,14 @@ def wps_scan(interface, bssid, essid):
 				statemachine.close()
 				continue # try same
 			elif errCode == 3:	# identity was rejected
-				print STATUS + 'WPS Is Not Supported'
+				print(STATUS + 'WPS Is Not Supported')
 				return False
 	except KeyboardInterrupt:
-		print '\n' + STATUS + 'Caught Ctrl+C'
+		print('\n' + STATUS + 'Caught Ctrl+C')
 		return False
 	return False
 
-def check_ap_connection(interface, bssid, essid, quite = True, verbose = False):
+def check_ap_connection(interface, bssid, essid, quite=True, verbose=False):
 	if not quite:
 		sys.stdout.write(STATUS + 'Checking Connection To AP')
 		sys.stdout.flush()
@@ -196,13 +238,13 @@ def check_ap_connection(interface, bssid, essid, quite = True, verbose = False):
 		while tries < 3:
 			statemachine = WirelessStateMachine(interface, bssid, RandMAC('00:*:*:*:*:*').__str__(), bssid)
 			if not quite and verbose:
-				print '\n' + STATUS + 'Verbose: using source MAC address: ' + statemachine.source_mac + ' for testing connections'
+				print('\n' + STATUS + 'Verbose: using source MAC address: ' + statemachine.source_mac + ' for testing connections')
 			errCode = statemachine.connect(essid)
 			if errCode != 0 and errCode < 4:
 				if not quite and verbose and errCode == 2:
-					print '\n' + ERROR + 'Verbose: did not receive a reply to the authentication request'
+					print('\n' + ERROR + 'Verbose: did not receive a reply to the authentication request')
 				if not quite and verbose and errCode == 3:
-					print '\n' + ERROR + 'Verbose: did not receive a reply to the association request'
+					print('\n' + ERROR + 'Verbose: did not receive a reply to the association request')
 				sleep(ERROR_SLEEP_TIME)
 				if not quite:
 					sys.stdout.write('.')
@@ -214,7 +256,7 @@ def check_ap_connection(interface, bssid, essid, quite = True, verbose = False):
 				tries = 0
 			break
 	except KeyboardInterrupt:
-		print '\n' + STATUS + 'Caught Ctrl+C'
+		print('\n' + STATUS + 'Caught Ctrl+C')
 		return False
 	if tries != 0:
 		if not quite:
@@ -229,66 +271,66 @@ def check_ap_connection(interface, bssid, essid, quite = True, verbose = False):
 	return True
 
 def main():
-	parser = argparse.ArgumentParser(description = 'EAPScan: Actively Enumerate 802.1x Wireless Networks', conflict_handler='resolve')
-	parser.add_argument('-e', '--essid', dest = 'essid', action = 'store', required = True, default = '', help = 'target ESSID')
-	parser.add_argument('-b', '--bssid', dest = 'bssid', action = 'store', required = True, default = '', help = 'target BSSID')
-	parser.add_argument('-i', '--iface', dest = 'iface', action = 'store', required = True, help = 'interface to use when capturing live')
-	parser.add_argument('-v', '--version', action = 'version', version = parser.prog + ' Version: ' + __version__)
-	parser.add_argument('-c', '--channel', dest = 'channel', action = 'store', required = False, default = 0, type = int, help = 'target channel')
-	parser.add_argument('-V', '--verbose', dest = 'verbose', action = 'store_true', default = False, help = 'provide verbose output')
-	parser.add_argument('--all', dest = 'scan_all', action = 'store_true', default = False, help = 'scan all EAP types (4-254)')
-	parser.add_argument('--check-wps', dest = 'check_wps', action = 'store_true', default = False, help = 'check if WPS is enabled')
-	parser.add_argument('--identity', dest = 'identity', action = 'store', default = 'eapscan', help = 'EAP outer identity string')
-	parser.add_argument('--types', dest = 'eap_types', nargs = '+', action = 'store', default = [], help = 'list of specific EAP types to try')
-	parser.add_argument('--xml', dest = 'save_xml', action = 'store_true', default = False, help = 'export data to xml')
+	parser = argparse.ArgumentParser(description='EAPScan: Actively Enumerate 802.1x Wireless Networks', conflict_handler='resolve')
+	parser.add_argument('-e', '--essid', dest='essid', action='store', required=True, default='', help='target ESSID')
+	parser.add_argument('-b', '--bssid', dest='bssid', action='store', required=True, default='', help='target BSSID')
+	parser.add_argument('-i', '--iface', dest='iface', action='store', required=True, help='interface to use when capturing live')
+	parser.add_argument('-v', '--version', action='version', version=parser.prog + ' Version: ' + __version__)
+	parser.add_argument('-c', '--channel', dest='channel', action='store', required=False, default=0, type=int, help='target channel')
+	parser.add_argument('-V', '--verbose', dest='verbose', action='store_true', default=False, help='provide verbose output')
+	parser.add_argument('--all', dest='scan_all', action='store_true', default=False, help='scan all EAP types (4-254)')
+	parser.add_argument('--check-wps', dest='check_wps', action='store_true', default=False, help='check if WPS is enabled')
+	parser.add_argument('--identity', dest='identity', action='store', default='eapscan', help='EAP outer identity string')
+	parser.add_argument('--types', dest='eap_types', nargs='+', action='store', default=[], help='list of specific EAP types to try')
+	parser.add_argument('--xml', dest='save_xml', action='store_true', default=False, help='export data to xml')
 	options = parser.parse_args()
 
 	if getuid():
-		print ERROR + 'Must Be Root To Inject Packets, Now Exiting...'
+		print(ERROR + 'Must Be Root To Inject Packets, Now Exiting...')
 		return 2
 
 	if not sanitizeMAC(options.bssid):
-		print ERROR + 'Invalid MAC Address, Now Exiting...'
+		print(ERROR + 'Invalid MAC Address, Now Exiting...')
 		return 3
 
-	if not checkInterface(options.iface) in [ 0, 1 ]:
-		print ERROR + 'Invalid Interface, Now Exiting...'
+	if not checkInterface(options.iface) in [0, 1]:
+		print(ERROR + 'Invalid Interface, Now Exiting...')
 		return 4
 	
 	if options.verbose:
-		print STATUS + 'Verbose output has been enabled'
+		print(STATUS + 'Verbose output has been enabled')
 	
 	if options.channel:
 		if not 0 < options.channel < 15:
-			print ERROR + 'Invalid Channel Selected, Must Be Between 1-14'
+			print(ERROR + 'Invalid Channel Selected, Must Be Between 1-14')
 			return 6
 		if not setInterfaceChannel(options.iface, options.channel, True):
-			print ERROR + 'Failed To Set The Selected Channel'
+			print(ERROR + 'Failed To Set The Selected Channel')
 			return 7
 
 	# Build the list of EAP types that we're scanning for
 	if options.check_wps:
 		# Make sure the AP is responding
 		if not check_ap_connection(options.iface, options.bssid, options.essid, False, options.verbose):
-			print ERROR + 'Now Exiting...'
+			print(ERROR + 'Now Exiting...')
 			return 0
 		wps_scan(options.iface, options.bssid, options.essid)
 		return 0
 		
 	if options.scan_all:
-		print STATUS + 'Scanning All EAP Types, This Could Take A While...'
+		print(STATUS + 'Scanning All EAP Types, This Could Take A While...')
 		check_range = range(4, 254)
 	elif options.eap_types:
 		check_range = []
 		for eaptype in options.eap_types:
 			if eaptype.upper() in EAP_TYPES.values():
-				eaptype = str(EAP_TYPES.keys()[ EAP_TYPES.values().index(eaptype.upper()) ])
+				eaptype = str(EAP_TYPES.keys()[EAP_TYPES.values().index(eaptype.upper())])
 			if eaptype.isdigit() and 3 < int(eaptype) < 255:
 				check_range.append(int(eaptype))
 			else:
-				print ERROR + 'Invalid EAP Type: ' + eaptype
+				print(ERROR + 'Invalid EAP Type: ' + eaptype)
 		if len(check_range) == 0:
-			print ERROR + 'No Usable EAP Types (4-254), Now Exiting...'
+			print(ERROR + 'No Usable EAP Types (4-254), Now Exiting...')
 			return 5
 	else:
 		check_range = EAP_TYPES.keys()
@@ -297,7 +339,7 @@ def main():
 
 	# Make sure the AP is responding
 	if not check_ap_connection(options.iface, options.bssid, options.essid, False, options.verbose):
-		print ERROR + 'Now Exiting...'
+		print(ERROR + 'Now Exiting...')
 		return 0
 
 	# Scan for the eap types
@@ -306,7 +348,7 @@ def main():
 	if options.save_xml:
 		eapeakParser = EapeakParsingEngine()
 		newNetwork = WirelessNetwork(options.essid, options.bssid)
-		[ newNetwork.addEapType(x) for x in valid_eap_types ]	# Python black magic trickery
+		[newNetwork.addEapType(x) for x in valid_eap_types]	# pylint: disable=expression-not-assigned
 		eapeakParser.KnownNetworks[options.essid] = newNetwork
 		eapeakParser.BSSIDToSSIDMap[options.bssid] = options.essid
 		eapeakParser.exportXML()

--- a/eapwn
+++ b/eapwn
@@ -1,77 +1,91 @@
 #!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  eapwn
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-"""
-	-*- coding: utf-8 -*-
-	eapwn
-	
-	Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-		
-"""
-
-__version__ = '0.0.4'
-__authors__ = [ 'Spencer McIntyre', 'SecureState R&D Team' ]
-
+# native imports
+import argparse
+from binascii import unhexlify
 import sys
+
+# project imports
+from eapeak.common import checkInterface, setInterfaceChannel
+from eapeak.inject import WirelessStateMachineSoftAPEAP
+from eapeak.parse import EapeakParsingEngine
+from ipfunc import getHwAddr
+
+#external imports
 try:
 	from scapy.layers.l2 import eap_types as EAP_TYPES
 except ImportError:
-	print 'Error: Missing Scapy Libraries, Please Install Scapy From The Community Repository'
+	print('Error: Missing Scapy Libraries, Please Install Scapy From The Community Repository')
 	# http://hg.secdev.org/scapy-com # needs community repository because of the extra EAP layers I added.
-	print 'Error: Now Exiting...'
+	print('Error: Now Exiting...')
 	sys.exit(1)
 
-import argparse
-from binascii import unhexlify
-from eapeak.common import checkInterface, setInterfaceChannel
-from eapeak.inject import *
-from eapeak.parse import EapeakParsingEngine
-from ipfunc import getHwAddr
+__version__ = '0.0.4'
+__authors__ = ['Spencer McIntyre', 'SecureState R&D Team']
 
 GOOD = '\033[1;32m[+]\033[1;m '
 STATUS = '\033[1;34m[*]\033[1;m '
 ERROR = '\033[1;31m[-]\033[1;m '
 
 def main():
-	parser = argparse.ArgumentParser(description = 'EAPwn: Python Soft AP For Client-Side EAP-Orientated Attacks', conflict_handler='resolve')
-	parser.add_argument('-v', '--version', action = 'version', version = parser.prog + ' Version: ' + __version__)
-	parser.add_argument('-e', '--essid', dest = 'essid', action = 'store', required = True, default = '', help = 'target ESSID')
-	parser.add_argument('-i', '--iface', dest = 'iface', action = 'store', required = True, help = 'interface to use when capturing live')
-	parser.add_argument('-b', '--bssid', dest = 'bssid', action = 'store', default = '', help = 'target BSSID')
-	parser.add_argument('-c', '--channel', dest = 'channel', action = 'store', required = False, default = 0, type = int, help = 'target channel')
+	parser = argparse.ArgumentParser(description='EAPwn: Python Soft AP For Client-Side EAP-Orientated Attacks', conflict_handler='resolve')
+	parser.add_argument('-v', '--version', action='version', version=parser.prog + ' Version: ' + __version__)
+	parser.add_argument('-e', '--essid', dest='essid', action='store', required=True, default='', help='target ESSID')
+	parser.add_argument('-i', '--iface', dest='iface', action='store', required=True, help='interface to use when capturing live')
+	parser.add_argument('-b', '--bssid', dest='bssid', action='store', default='', help='target BSSID')
+	parser.add_argument('-c', '--channel', dest='channel', action='store', required=False, default=0, type=int, help='target channel')
 	#parser.add_argument('--eap', dest = 'use_eap', action = 'store_true', default = False, help = 'enable fake EAP requests')
-	parser.add_argument('--types', dest = 'eap_types', nargs = '+', action = 'store', default = [ '17' ], help = 'list of specific EAP types to support')
-	parser.add_argument('--mschap', dest = 'mschap_challenge', action = 'store', default = None, help = 'specify a static MSChap challenge to use')
-	parser.add_argument('--xml', dest = 'save_xml', action = 'store_true', default = False, help = 'export data to xml')
+	parser.add_argument('--types', dest='eap_types', nargs='+', action='store', default=['17'], help='list of specific EAP types to support')
+	parser.add_argument('--mschap', dest='mschap_challenge', action='store', default=None, help='specify a static MSChap challenge to use')
+	parser.add_argument('--xml', dest='save_xml', action='store_true', default=False, help='export data to xml')
 	options = parser.parse_args()
 	del parser
 	
-	if not checkInterface(options.iface) in [ 0, 1 ]:
-		print ERROR + 'Invalid Interface, Now Exiting...'
+	if not checkInterface(options.iface) in [0, 1]:
+		print(ERROR + 'Invalid Interface, Now Exiting...')
 		return 1
 	
 	if options.channel:
 		if not 0 < options.channel < 15:
-			print ERROR + 'Invalid Channel Selected, Must Be Between 1-14'
+			print(ERROR + 'Invalid Channel Selected, Must Be Between 1-14')
 			return 6
 		if not setInterfaceChannel(options.iface, options.channel, True):
-			print ERROR + 'Failed To Set The Selected Channel'
+			print(ERROR + 'Failed To Set The Selected Channel')
 			return 7
 	
 	if options.bssid:
@@ -87,40 +101,40 @@ def main():
 	
 	for eaptype in options.eap_types:
 		if eaptype.upper() in EAP_TYPES.values():
-			eaptype = str(EAP_TYPES.keys()[ EAP_TYPES.values().index(eaptype.upper()) ])
+			eaptype = str(EAP_TYPES.keys()[EAP_TYPES.values().index(eaptype.upper())])
 		if not eaptype.isdigit():
-			print ERROR + 'Invalid EAP Type: ' + eaptype
+			print(ERROR + 'Invalid EAP Type: ' + eaptype)
 			return
 		if not softap.addEapType(int(eaptype)):
-			print ERROR + 'Unsupported EAP Type: ' + str(eaptype)
+			print(ERROR + 'Unsupported EAP Type: ' + str(eaptype))
 			return
 
 	if options.mschap_challenge != None:
 		try:
 			softap.mschap_challenge = unhexlify(options.mschap_challenge.replace(':', ''))
 		except ValueError:
-			print ERROR + 'Invalid MSChap Challenge String (Length Must Be 8 Bytes)'
+			print(ERROR + 'Invalid MSChap Challenge String (Length Must Be 8 Bytes)')
 			return
-		except:
-			print ERROR + 'Invalid MSChap Challenge String'
+		except: # pylint: disable=bare-except
+			print(ERROR + 'Invalid MSChap Challenge String')
 			return
 
 	softap.listen(5, 0.25)	# TODO add broadcast_interval options
-	print "{0}Started EAPwn Soft AP, Version: {1}\n{0}\tESSID: {2}\n{0}\tBSSID: {3}\n{0}\tInterface: {4}\n{0}\tEAP Types: {5}".format(STATUS, __version__, options.essid, bssid, options.iface, ", ".join(EAP_TYPES[x] for x in softap.eap_priorities))
+	print("{0}Started EAPwn Soft AP, Version: {1}\n{0}\tESSID: {2}\n{0}\tBSSID: {3}\n{0}\tInterface: {4}\n{0}\tEAP Types: {5}".format(STATUS, __version__, options.essid, bssid, options.iface, ", ".join(EAP_TYPES[x] for x in softap.eap_priorities)))
 	try:
 		while True:
-			(sockObj, clientMAC) = softap.accept()
-			print GOOD + 'Received Client Connection:'
-			print sockObj.clientDescriptor.show(1)
+			sockObj = softap.accept()
+			print(GOOD + 'Received Client Connection:')
+			print(sockObj.clientDescriptor.show(1))
 	except KeyboardInterrupt:
 		pass
 	except:
-		print ERROR + 'A Fatal Error Has Occured.'
-		print ERROR + 'Shutting Down, Please Wait...'
+		print(ERROR + 'A Fatal Error Has Occured.')
+		print(ERROR + 'Shutting Down, Please Wait...')
 		softap.shutdown()
 		raise
 	if not softap.__shutdown__:
-		print STATUS + 'Shutting Down, Please Wait...'
+		print(STATUS + 'Shutting Down, Please Wait...')
 		while not softap.__shutdown__:
 			try:
 				softap.shutdown()
@@ -129,7 +143,7 @@ def main():
 				pass
 	
 	if options.save_xml:
-		print STATUS + 'Exporting Data To XML...'
+		print(STATUS + 'Exporting Data To XML...')
 		eapeakParser = EapeakParsingEngine()
 		eapeakParser.KnownNetworks[softap.essid] = softap.networkDescriptor
 		eapeakParser.BSSIDToSSIDMap[softap.bssid] = softap.essid

--- a/lib/eapeak/clients.py
+++ b/lib/eapeak/clients.py
@@ -1,33 +1,50 @@
-"""
-	-*- coding: utf-8 -*-
-	clients.py
-	Provided by Package: eapeak
-	
-	Author: Spencer McIntyre <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-		
-"""
+#!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  lib/eapeak/clients.py
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-from scapy.layers.l2 import eap_types as EAP_TYPES
-from binascii import hexlify
+# native imports
 from base64 import standard_b64encode as b64encode
+from binascii import hexlify
 from xml.sax.saxutils import escape as XMLEscape
+
+# project imports
+
+# external imports
+from scapy.layers.l2 import eap_types as EAP_TYPES
+
 EAP_TYPES[0] = 'NONE'
 
 class WirelessClient:
@@ -63,7 +80,7 @@ class WirelessClient:
 		if not identity in self.identities.keys() and identity:
 			self.identities[identity] = eaptype
 			
-	def addMSChapInfo(self, eaptype, challenge = None, response = None, identity = None):
+	def addMSChapInfo(self, eaptype, challenge=None, response=None, identity=None):
 		"""
 		Adds information to the internal "mschap" list which contains
 		dictionaries for each set with keys of:
@@ -97,7 +114,7 @@ class WirelessClient:
 			else:
 				return 2												# we seem to have received 2 response strings without a challenge in between
 
-	def show(self, tabs = 0):
+	def show(self, tabs=0):
 		"""
 		This returns a string of human readable information describing
 		the client object, tabs is an optional offset.
@@ -135,7 +152,7 @@ class WirelessClient:
 					if the_cheese_stands_alone:
 						output += ('\t' * tabs) + 'WPS Information:\n'
 						the_cheese_stands_alone = False
-					output += ('\t' * tabs) + '\t' + piece + ': ' + self.wpsData[piece] + '\n'
+					output += ('\t' * tabs) + '\t' + piece + ': ' + self.wpsData[piece] + '\n' # pylint: disable=unsubscriptable-object
 		return output.rstrip()
 
 	def getXML(self):
@@ -154,7 +171,8 @@ class WirelessClient:
 			tmp.text = XMLEscape(identity)
 			
 		for respObj in self.mschap:
-			if not 'r' in respObj: continue
+			if not 'r' in respObj:
+				continue
 			tmp = ElementTree.SubElement(root, 'mschap')
 			tmp.set('eap-type', str(respObj['t']))
 			tmp.set('identity', XMLEscape(respObj['i']))
@@ -166,10 +184,10 @@ class WirelessClient:
 			for info in ['manufacturer', 'model name', 'model number', 'device name']:
 				if self.wpsData.has_key(info):
 					tmp = ElementTree.SubElement(wps, info.replace(' ', '-'))
-					tmp.text = self.wpsData[info]
+					tmp.text = self.wpsData[info] # pylint: disable=unsubscriptable-object
 			for info in ['uuid', 'registrar nonce', 'enrollee nonce']:	# values that should be base64 encoded
 				if self.wpsData.has_key(info):
 					tmp = ElementTree.SubElement(wps, info.replace(' ', '-'))
 					tmp.set('encoding', 'base64')
-					tmp.text = b64encode(self.wpsData[info])
+					tmp.text = b64encode(self.wpsData[info]) # pylint: disable=unsubscriptable-object
 		return root

--- a/lib/eapeak/networks.py
+++ b/lib/eapeak/networks.py
@@ -1,36 +1,52 @@
-"""
-	-*- coding: utf-8 -*-
-	networks.py
-	Provided by Package: eapeak
-	
-	Author: Spencer McIntyre <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-		
-"""
+#!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  lib/eapeak/networks.py
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-from scapy.layers.l2 import eap_types as EAP_TYPES
-from xml.sax.saxutils import escape as XMLEscape
+# native imports
 from base64 import standard_b64encode as b64encode
-from M2Crypto import X509
-from eapeak.common import EXPANDED_EAP_VENDOR_IDS
-EAP_TYPES[0] = 'NONE'
+from xml.sax.saxutils import escape as XMLEscape
 
+# project imports
+from eapeak.common import EXPANDED_EAP_VENDOR_IDS
+
+# external imports
+from M2Crypto import X509
+from scapy.layers.l2 import eap_types as EAP_TYPES
+
+EAP_TYPES[0] = 'NONE'
 
 class WirelessNetwork:
 	"""
@@ -42,7 +58,7 @@ class WirelessNetwork:
 	"""
 	ssid = ''	# this is unique
 	
-	def __init__(self, ssid, bssid = ''):
+	def __init__(self, ssid, bssid=''):
 		self.bssids = []
 		self.clients = {}	# indexed by client MAC
 		self.eapTypes = []
@@ -69,7 +85,7 @@ class WirelessNetwork:
 		if not isinstance(certificate, X509.X509):
 			try:
 				certificate = X509.load_cert_string(certificate, X509.FORMAT_DER)
-			except:
+			except: # pylint: disable=bare-except
 				return 1
 				
 		newFingerprint = certificate.get_fingerprint()
@@ -105,10 +121,7 @@ class WirelessNetwork:
 		"""
 		Checks that a client has been seen with this network.
 		"""
-		if client_mac in self.clients.keys():
-			return True
-		else:
-			return False
+		return client_mac in self.clients.keys()
 	
 	def getClient(self, client_mac):
 		"""
@@ -148,7 +161,7 @@ class WirelessNetwork:
 					if the_cheese_stands_alone:
 						output += '\tWPS Information:\n'
 						the_cheese_stands_alone = False
-					output += '\t\t' + piece + ': ' + self.wpsData[piece] + '\n'
+					output += '\t\t' + piece + ': ' + self.wpsData[piece] + '\n' # pylint: disable=unsubscriptable-object
 		if self.clients:
 			output += '\tClient Data:\n'
 			i = 1
@@ -174,7 +187,6 @@ class WirelessNetwork:
 					output += '\n\t\t\tCN: ' + X509_Name_Entry_inst.get_data().as_text()
 				for X509_Name_Entry_inst in data.get_entries_by_nid(18): 	# 18 is OU
 					output += '\n\t\t\tOU: ' + X509_Name_Entry_inst.get_data().as_text()
-				key_size = (cert.get_pubkey().size()) * 8
 				del data
 				output += '\n'
 				i += 1
@@ -206,12 +218,12 @@ class WirelessNetwork:
 			for info in ['manufacturer', 'model name', 'model number', 'device name']:
 				if self.wpsData.has_key(info):
 					tmp = ElementTree.SubElement(wps, info.replace(' ', '-'))
-					tmp.text = self.wpsData[info]
+					tmp.text = self.wpsData[info] # pylint: disable=unsubscriptable-object
 			for info in ['uuid', 'registrar nonce', 'enrollee nonce']:	# values that should be base64 encoded
 				if self.wpsData.has_key(info):
 					tmp = ElementTree.SubElement(wps, info.replace(' ', '-'))
 					tmp.set('encoding', 'base64')
-					tmp.text = b64encode(self.wpsData[info])
+					tmp.text = b64encode(self.wpsData[info]) # pylint: disable=unsubscriptable-object
 		for client in self.clients.values():
 			root.append(client.getXML())
 		for cert in self.x509certs:

--- a/setup.py
+++ b/setup.py
@@ -1,65 +1,86 @@
-#! /usr/bin/python
+#!/usr/bin/env python
+#
+# -*- coding: utf-8 -*-
+#
+#  setup.py
+#
+#  Author: Spencer McIntyre (Steiner) <smcintyre [at] securestate [dot] com>
+#
+#  Copyright 2011 SecureState
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Shout outs to the SecureState Profiling Team (Thanks Guys!)
+#    agent0x0
+#    f8lerror
+#    jagar
+#    WhIPsmACK0
+#    Zamboni
+#
+#  Additional Thanks To:
+#    Joshua Wright
+#    Zero_Chaos
+#    Steve Ocepek
 
-"""
-	-*- coding: utf-8 -*-
-	setup.py
-	
-	Author: Spencer McIntyre <smcintyre [at] securestate [dot] com>
-	
-	Copyright 2011 SecureState
-	
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-	
-	You should have received a copy of the GNU General Public License
-	along with this program; if not, write to the Free Software
-	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-	MA 02110-1301, USA.
-
-"""
-
-from distutils.core import setup
-from os import listdir
+# native imports
 from sys import version_info as version
 
-py_modules = [ 'ipfunc' ]
+# project imports
+
+# external imports
+from distutils.core import setup
+
+py_modules = ['ipfunc']
 if version[0] == 2 and version[1] < 7:
 	py_modules.append('argparse')
 
 setup(
-	name = 'EAPeak',
-	version = '0.1.4',
-	description = 'EAPeak Wireless Analysis Suite',
+	name='EAPeak',
+	version='0.1.4',
+	description='EAPeak Wireless Analysis Suite',
 	
 	# Author
-	author = 'Spencer McIntyre',
-	author_email = 'SMcIntyre [at] SecureState [dot] com',
+	author='Spencer McIntyre',
+	author_email='SMcIntyre [at] SecureState [dot] com',
 	
 	# Maintainer
-	maintainer = 'Spencer McIntyre',
-	maintainer_email = 'SMcIntyre [at] SecureState [dot] com',
+	maintainer='Spencer McIntyre',
+	maintainer_email='SMcIntyre [at] SecureState [dot] com',
 	
-	url = 'http://www.securestate.com/',
-	download_url = 'http://www.securestate.com/',
+	url='http://www.securestate.com/',
+	download_url='http://www.securestate.com/',
 	
 	# EAPeak's required packages
-	requires = [ 'scapy', 'M2Crypto' ],
+	requires=['scapy', 'M2Crypto'],
 	
 	# EAPeak's package data
-	provides = [ 'eapeak' ],
-	packages = [ 'eapeak' ],
-	package_dir = { '': 'lib' },
-	py_modules = py_modules,
+	provides=['eapeak'],
+	packages=['eapeak'],
+	package_dir={'': 'lib'},
+	py_modules=py_modules,
 	
-	scripts = [ 'eapeak', 'eapscan', 'eapwn' ],
-	data_files = [	
-					('/usr/share/man/man1', ['data/man/eapeak.1.gz', 'data/man/eapscan.1.gz', 'data/man/eapwn.1.gz'])
-					]
-	)
+	scripts=['eapeak', 'eapscan', 'eapwn'],
+	data_files=[
+		(
+			'/usr/share/man/man1',
+			[
+				'data/man/eapeak.1.gz',
+				'data/man/eapscan.1.gz',
+				'data/man/eapwn.1.gz'
+			]
+		)
+	]
+)


### PR DESCRIPTION
The majority of these changes are for making alterations to the code - whether by squelching or by fixing the cause - in order to reduce messages generated by running PyLint. The following message types were ignored altogether:
- line-too-long
- superfluous-parens
- trailing-whitespace
- bad-continuation
- redefined-variable-type
- too-many-return-statements
- too-many-branches
- too-many-statements
- too-many-lines
- too-many-instance-attributes
- too-many-locals
- too-many-nested-blocks
- wrong-import-order
- attribute-defined-outside-init
- undefined-loop-variable
- dangerous-default-value
- anomalous-backslash-in-string

The rest of the messages were either disabled locally (as the instances of these messages are acceptable) or left to be reviewed later (specifically, three instances of 'fixme' and one instance of 'redefined-builtin').

Beyond these changes for the sake of PyLint, a couple of style/format alterations were made; some continuation was cleaned up, import statements were organized, and the file headers were changed from existing as a string to existing at commenting. No other, larger changes were made in the code concerning style or format.
